### PR TITLE
Use FFmpeg built-in DFPWM encoder

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -5,7 +5,6 @@ import os from "os";
 import path from "path";
 import fs from "fs";
 import prism from "prism-media";
-import dfpwm from "dfpwm";
 
 const ytmusic = new YTMusic()
 await ytmusic.initialize()
@@ -35,12 +34,12 @@ export const ipod = onRequest({ memory: "512MiB", maxInstances: 3 }, (req, res) 
                 .then(function (json) {
                     if (json.url) {
 
-                        // Transcode the audio from opus to s8. This reduces the file size and gets it ready for the dfpwm encoder.
+                        // Transcode the audio from opus to dfpwm. This reduces the file size.
                         const transcoder = new prism.FFmpeg({
                             args: [
                                 '-analyzeduration', '0',
                                 '-loglevel', '0',
-                                '-f', 's8',
+                                '-f', 'dfpwm',
                                 '-ar', '48000',
                                 '-ac', '1'
                             ]
@@ -52,7 +51,6 @@ export const ipod = onRequest({ memory: "512MiB", maxInstances: 3 }, (req, res) 
                             if (response.ok) {
                                 response.body
                                     .pipe(transcoder)
-                                    .pipe(new dfpwm.Encoder())
                                     .pipe(fs.createWriteStream(filepath))
                                     .on('finish', function () {
                                         resolve(res.status(200).send(fs.readFileSync(filepath)));

--- a/functions/package.json
+++ b/functions/package.json
@@ -4,7 +4,6 @@
   },
   "dependencies": {
     "@discordjs/opus": "^0.9.0",
-    "dfpwm": "github:terreng/node-dfpwm#master",
     "firebase-functions": "^5.0.1",
     "node-fetch": "^3.3.2",
     "prism-media": "^1.3.5",


### PR DESCRIPTION
This PR adjusts the encoder settings to output to DFPWM directly, as supported by FFmpeg 5.1 and later. There's no need to encode to s8 first, as this is a waste of computation/CPU time. This also removes the dependency on node-dfpwm.